### PR TITLE
feat(lang/java): 优化 “更高速的输入输出” 部分的描述

### DIFF
--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -286,7 +286,7 @@ class Test {
 
 #### 使用 StreamTokenizer 作为输入
 
-在某些情况使用 `StringTokenizer` 会出现 MLE（Memory Limit Exceeded，超过内存上限）的错误，此时我们需要使用 `StreamTokenizer` 作为输入。
+在某些情况使用 `StringTokenizer` 会出现 MLE（Memory Limit Exceeded，超过内存上限）错误，此时我们需要使用 `StreamTokenizer` 作为输入。
 
 ```java
 import java.io.*;
@@ -313,7 +313,7 @@ public class Main {
 
 #### Kattio + StringTokenizer 的方法与 StreamTokenizer 的方法之间的分析与对比
 
-1.  `StreamTokenizer` 相较于 `StringTokenizer` 内存较小，当你在使用 java 标程却依旧 `MLE` 时可以尝试 `StreamTokenizer`，但是 `StreamTokenizer` 会丢失精度，读入部分数据会出现问题；
+1.  `StreamTokenizer` 相较于 `StringTokenizer` 使用的内存较少，当你在使用 Java 标程却依旧出现 `MLE` 错误时可以尝试使用 `StreamTokenizer`，但是 `StreamTokenizer` 会丢失精度，读入部分数据时会出现问题；
     - `StreamTokenizer` 源码存在 `Type`，该 `Type` 根据你输入内容来决定类型，倘若你输入类似于 `123oi` 以 **数字开头** 的字符串，他会强制认为你的类型是 double 类型，因此在读入中以 `double` 类型去读 `String` 类型便会抛出异常；
     - `StreamTokenizer` 在读入 `1e14` 以上大小的数字会丢失精度；
 2. 在使用 `PrintWriter` 情况下，需注意在程序结束最后 `close()` 关闭输出流或在需要输出的时候使用 `flush()` 清除缓冲区，否则内容将不会被写入到控制台/文件中。

--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -228,9 +228,11 @@ class Test {
 
 ### 更高速的输入输出
 
-`Scanner` 和 `System.out.print` 在最开始会工作的很好，但是在处理更大的输入的时候会降低效率，因此我们会使用来自 Kattis 的 [Kattio.java](https://github.com/Kattis/kattio/blob/master/Kattio.java) 来提高 IO 效率。[^ref1]
+`Scanner` 和 `System.out.print` 在最开始会工作的很好，但是在处理更大的输入的时候会降低效率，因此我们会需要使用一些方法来提高 IO 速度。
 
-#### 使用 Kattio+StringTokenizer 作为输入
+#### 使用 Kattio + StringTokenizer 作为输入
+
+最常用的方法之一是使用来自 Kattis 的 [Kattio.java](https://github.com/Kattis/kattio/blob/master/Kattio.java) 来提高 IO 效率。[^ref1] 这个方法会将 `StringTokenizer` 与 `PrintWriter` 包装在一个类中方便使用。而在具体进行解题的时候（假如赛会/组织方允许）可以直接使用这个模板。
 
 下方即为应包含在代码中的 IO 模板，由于 Kattis 的原 Kattio 包含一些并不常用的功能，下方的模板经过了一些调整（原 Kattio 使用 MIT 作为协议）。
 
@@ -284,9 +286,12 @@ class Test {
 
 #### 使用 StreamTokenizer 作为输入
 
+在某些情况使用 `StringTokenizer` 会出现 MLE（Memory Limit Exceeded，超过内存上限）的错误，此时我们需要使用 `StreamTokenizer` 作为输入。
+
 ```java
 import java.io.*;
 public class Main {
+    // IO 代码
     public static StreamTokenizer in = new StreamTokenizer(new BufferedReader(new InputStreamReader(System.in),32768));
     public static PrintWriter out = new PrintWriter(new OutputStreamWriter(System.out));
     public static double nextDouble() throws IOException{ in.nextToken(); return in.nval; }
@@ -296,8 +301,9 @@ public class Main {
         return in.sval;
     }
     public static long nextLong() throws Exception{ in.nextToken();return (long)in.nval;}
+    
+    // 使用示例
     public static void main(String[] args) throws Exception{
-        //do something
         int n=nextInt();
         out.println(n);
         out.flush();
@@ -305,15 +311,13 @@ public class Main {
 }
 ```
 
-#### kattio+StringTokenizer 与 StreamTokenizer 和 PrintWriter 的分析与对比
+#### Kattio + StringTokenizer 的方法与 StreamTokenizer 的方法之间的分析与对比
 
-1.  `StreamTokenizer` 相较于 `StringTokenizer` 内存较小，当你在使用 java 标程却依旧 `MLE` 时可以尝试 `StreamTokenizer`，但是 `StreamTokenizer` 会丢精度，读入部分数据会出现问题；
-    - `StreamTokenizer` 源码存在 Type，该 Type 根据你输入内容来决定类型，倘若你输入类似于 `123oi` 以 **数字开头** 的字符串，他会强制认为你的类型是 double 类型，因此在读入中以 double 类型去读 String 类型便会抛出异常；
-    - `StreamTokenizer` 在读入 1e14 以上大小的数字会丢失精度；
-
-2. 在使用 `PrintWriter` 情况下，需注意在程序结束最后 flush 清除缓冲区，否则控制台将会没有输出。
-
-3. `Kattio` 是继承自 `PrintWriter` 类，自身对象具有了 `PrintWriter` 的功能，因此可以直接调用 `PrintWriter` 类的函数输出，同时将 StringTokenizer 作为了自身的成员变量来修改。而第二种 `Main` 是同时将 `StreamTokenizer` 与 `PrintWriter` 作为了自身的成员变量，因此在使用上有些许差距。
+1.  `StreamTokenizer` 相较于 `StringTokenizer` 内存较小，当你在使用 java 标程却依旧 `MLE` 时可以尝试 `StreamTokenizer`，但是 `StreamTokenizer` 会丢失精度，读入部分数据会出现问题；
+    - `StreamTokenizer` 源码存在 `Type`，该 `Type` 根据你输入内容来决定类型，倘若你输入类似于 `123oi` 以 **数字开头** 的字符串，他会强制认为你的类型是 double 类型，因此在读入中以 `double` 类型去读 `String` 类型便会抛出异常；
+    - `StreamTokenizer` 在读入 `1e14` 以上大小的数字会丢失精度；
+2. 在使用 `PrintWriter` 情况下，需注意在程序结束最后 `close()` 关闭输出流或在需要输出的时候使用 `flush()` 清除缓冲区，否则内容将不会被写入到控制台/文件中。
+3. `Kattio` 是继承自 `PrintWriter` 类，自身对象具有了 `PrintWriter` 的功能，因此可以直接调用 `PrintWriter` 类的函数输出，同时将 `StringTokenizer` 作为了自身的成员变量来修改。而第二种 `Main` 是同时将 `StreamTokenizer` 与 `PrintWriter` 作为了自身的成员变量，因此在使用上有些许差距。
 
 综上所述，在大部分情况下，`StringTokenizer` 的使用处境要优越于 `StreamTokenizer`，在极端 MLE 的情况下可以尝试 `StreamTokenizer`，同时 int 范围以上的数据 `StreamTokenizer` 处理是无能为力的
 


### PR DESCRIPTION
优化了一下描述，包括：

* 统一 ` `` ` 的使用
* 英语前后的空格（增加可读性）
* 更清晰的解释了不同部分（`使用 Kattio + StringTokenizer 作为输入` 与 `使用 StreamTokenizer 作为输入`）

---

目前的问题：

* 315 - 318 行被缩进的无序列表前后的空行需要调整